### PR TITLE
Accept for both `yeet` and `del` for legacy support

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -42,7 +42,7 @@ type_expressions[asdl_expr_seq*]:
             CHECK(asdl_seq*, _PyPegen_seq_append_to_end(p, a, b)),
             c) }
     | a=','.expression+ ',' '*' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
-    | a=','.expression+ ',' '**' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, expressiona, b) }
+    | a=','.expression+ ',' '**' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
     | '*' a=expression ',' '**' b=expression {
         (asdl_expr_seq*)_PyPegen_seq_append_to_end(
             p,

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -42,7 +42,7 @@ type_expressions[asdl_expr_seq*]:
             CHECK(asdl_seq*, _PyPegen_seq_append_to_end(p, a, b)),
             c) }
     | a=','.expression+ ',' '*' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
-    | a=','.expression+ ',' '**' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
+    | a=','.expression+ ',' '**' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, expressiona, b) }
     | '*' a=expression ',' '**' b=expression {
         (asdl_expr_seq*)_PyPegen_seq_append_to_end(
             p,
@@ -131,7 +131,7 @@ yield_stmt[stmt_ty]: y=yield_expr { _PyAST_Expr(y, EXTRA) }
 assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _PyAST_Assert(a, b, EXTRA) }
 
 del_stmt[stmt_ty]:
-    | ('de', 'yeet') a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
+    | ('del', 'yeet') a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
     | invalid_del_stmt
 
 import_stmt[stmt_ty]: import_name | import_from

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -71,7 +71,7 @@ simple_stmt[stmt_ty] (memo):
     | &('import' | 'from') import_stmt
     | &'raise' raise_stmt
     | 'pass' { _PyAST_Pass(EXTRA) }
-    | &'yeet' del_stmt
+    | &('del', 'yeet') del_stmt
     | &'yield' yield_stmt
     | &'assert' assert_stmt
     | 'break' { _PyAST_Break(EXTRA) }
@@ -131,7 +131,7 @@ yield_stmt[stmt_ty]: y=yield_expr { _PyAST_Expr(y, EXTRA) }
 assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _PyAST_Assert(a, b, EXTRA) }
 
 del_stmt[stmt_ty]:
-    | 'yeet' a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
+    | ('de', 'yeet') a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
     | invalid_del_stmt
 
 import_stmt[stmt_ty]: import_name | import_from


### PR DESCRIPTION
This would enable us to use python modules without modifying them.